### PR TITLE
fix: correct spec drift and quality gate metrics

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/Project-Navi/navi-bootstrap/security/advisories/new
+    url: https://github.com/Project-Navi/repo/security/advisories/new
     about: Report security vulnerabilities privately

--- a/.github/quality-gate.json
+++ b/.github/quality-gate.json
@@ -1,8 +1,8 @@
 {
   "version": 1,
-  "updated_at": "2026-02-25T00:00:00+00:00",
+  "updated_at": "2026-02-27T00:00:00+00:00",
   "coverage_pct": 89,
-  "test_count": 125,
+  "test_count": 490,
   "parity_violations": 0,
   "unwired_symbols": 0,
   "lifecycle_asymmetries": 0,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
     rev: 1.9.3
     hooks:
       - id: bandit
-        args: [-r, src/navi_bootstrap, -ll, -q]
+        args: [-r, "src/navi_bootstrap", -ll, -q]
         files: ^src\/navi_bootstrap/
         pass_filenames: false
 

--- a/nboot-spec.json
+++ b/nboot-spec.json
@@ -2,8 +2,13 @@
   "name": "navi-bootstrap",
   "version": "0.1.0",
   "description": "Jinja2 rendering engine and template packs for bootstrapping projects to navi-os-grade posture",
+  "license": "MIT",
   "language": "python",
   "python_version": "3.12",
+
+  "author": {
+    "name": "Nelson Spencer"
+  },
 
   "structure": {
     "src_dir": "src/navi_bootstrap",
@@ -12,7 +17,11 @@
 
   "dependencies": {
     "runtime": ["click", "jinja2", "pyyaml", "jsonschema"],
-    "dev": ["pytest", "pytest-cov", "ruff", "mypy"],
+    "dev": [
+      "pytest", "pytest-cov", "ruff", "mypy", "bandit",
+      "agno", "lancedb", "PyGithub", "sqlalchemy",
+      "types-jsonschema", "types-PyYAML"
+    ],
     "optional": {}
   },
 
@@ -32,11 +41,18 @@
 
   "recon": {
     "test_framework": "pytest",
-    "test_count": 471,
+    "test_count": 490,
     "coverage_pct": 89,
     "python_test_versions": ["3.12", "3.13"],
     "codeql_languages": ["python"],
-    "existing_ci": ["tests.yml"],
+    "existing_ci": [
+      "_build-reusable.yml",
+      "codeql.yml",
+      "grippy-review.yml",
+      "release.yml",
+      "scorecard.yml",
+      "tests.yml"
+    ],
     "existing_tools": {
       "ruff": true,
       "mypy": true,
@@ -46,6 +62,6 @@
     },
     "has_pyproject_toml": true,
     "has_github_dir": true,
-    "updated_at": "2026-02-26T00:00:00+00:00"
+    "updated_at": "2026-02-27T00:00:00+00:00"
   }
 }


### PR DESCRIPTION
## Summary
- **quality-gate.json:** test count 125 → 490, date updated to reflect current state
- **nboot-spec.json:** test count 471 → 490, added `license`, `author`, full dev dependency list, all 6 CI workflows
- **issue template:** fix security advisory URL (`navi-bootstrap` → `repo`)
- **pre-commit:** quote bandit `src` path arg for YAML safety

## Test plan
- [ ] CI passes (no code changes — config/metadata only)
- [ ] `nboot-spec.json` validates against schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)