### PR TITLE
feat: add PyPI publishing via trusted publisher

### DIFF
--- a/.github/workflows/_build-reusable.yml
+++ b/.github/workflows/_build-reusable.yml
@@ -89,13 +89,40 @@ jobs:
             licenses.csv \
             licenses.txt
 
+      - name: Build package
+        run: uv build
+
       - name: Attest release artifacts
         uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2  # v2.2.3
         with:
           subject-path: |
+            dist/*
             sbom.cdx.json
             sbom.spdx.json
             licenses.csv
             licenses.txt
 
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
 
+  publish:
+    needs: build-and-release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download dist artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
## Summary

- Adds `uv build` step to the release workflow
- Adds `publish` job using `pypa/gh-action-pypi-publish` with OIDC trusted publisher (no API tokens)
- Requires `pypi` GitHub environment with manual approval gate
- Attests dist artifacts alongside SBOMs

## To release

After merge:
```bash
git tag v0.1.0
git push origin v0.1.0
```

Then approve the deployment in GitHub Actions.

## Test plan

- [x] Trusted publisher configured on PyPI (project: navi-bootstrap, env: pypi)
- [x] GitHub environment `pypi` created with required reviewer
- [ ] Tag v0.1.0 triggers release workflow
- [ ] Approve deployment, package appears on PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)