### PR TITLE
fix: detect async def test_ functions in project inspector

### DIFF
--- a/src/navi_bootstrap/init.py
+++ b/src/navi_bootstrap/init.py
@@ -249,7 +249,7 @@ def detect_test_info(target: Path) -> dict[str, Any]:
             content = test_file.read_text(errors="replace")
         except (PermissionError, OSError):
             continue
-        count += len(re.findall(r"^\s*def test_", content, re.MULTILINE))
+        count += len(re.findall(r"^\s*(?:async\s+)?def test_", content, re.MULTILINE))
 
     return {
         "test_framework": "pytest",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -447,11 +447,18 @@ class TestDetectTestInfo:
         (tests / "test_core.py").write_text("def test_it(): pass\n")
         (tests / "helpers.py").write_text("def helper(): pass\n")
         result = detect_test_info(tmp_path)
-        assert result["test_count"] == 1      def test_detects_async_test_functions(self, tmp_path: Path) -> None:         tests = tmp_path / "tests"         tests.mkdir()         test_file = tests / "test_example.py"         test_file.write_text(             "def test_sync(): pass
-"             "async def test_async(): pass
-"         )         info = detect_test_info(tmp_path)         assert info["test_count"] == 2
+        assert result["test_count"] == 1
 
-
+    def test_detects_async_test_functions(self, tmp_path: Path) -> None:
+        tests = tmp_path / "tests"
+        tests.mkdir()
+        test_file = tests / "test_example.py"
+        test_file.write_text(
+            "def test_sync(): pass\n"
+            "async def test_async(): pass\n"
+        )
+        info = detect_test_info(tmp_path)
+        assert info["test_count"] == 2
 # ---------------------------------------------------------------------------
 # TestInspectProject
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -457,8 +457,8 @@ class TestDetectTestInfo:
             "def test_sync(): pass\n"
             "async def test_async(): pass\n"
         )
-        info = detect_test_info(tmp_path)
-        assert info["test_count"] == 2
+        result = detect_test_info(tmp_path)
+        assert result["test_count"] == 2
 # ---------------------------------------------------------------------------
 # TestInspectProject
 # ---------------------------------------------------------------------------

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -447,7 +447,9 @@ class TestDetectTestInfo:
         (tests / "test_core.py").write_text("def test_it(): pass\n")
         (tests / "helpers.py").write_text("def helper(): pass\n")
         result = detect_test_info(tmp_path)
-        assert result["test_count"] == 1
+        assert result["test_count"] == 1      def test_detects_async_test_functions(self, tmp_path: Path) -> None:         tests = tmp_path / "tests"         tests.mkdir()         test_file = tests / "test_example.py"         test_file.write_text(             "def test_sync(): pass
+"             "async def test_async(): pass
+"         )         info = detect_test_info(tmp_path)         assert info["test_count"] == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description

The regex in `src/navi_bootstrap/init.py` (line 252) used to count test functions only matched synchronous `def test_*` functions:

```python
# Before
count += len(re.findall(r"^\s*def test_", content, re.MULTILINE))
```

This missed `async def test_*` functions, causing `test_count` to be undercounted for projects using `pytest-asyncio` or any async test suite.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Test coverage
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist

- [x] My code follows the project's style (`ruff check src/navi_bootstrap/ tests/`)
- [x] I have added tests for my changes
- [ ] I have updated documentation if needed
- [x] All existing tests pass (`pytest tests/ -v`)

## Related Issues

Fixes #32

## Additional Notes

The fix updates the regex to use a non-capturing optional group `(?:async\s+)?` so both sync and async test functions are detected:

```python
# After
count += len(re.findall(r"^\s*(?:async\s+)?def test_", content, re.MULTILINE))
```

A new test `test_detects_async_test_functions` was added to `TestDetectTestInfo` to cover this case.