### PR TITLE
docs: add help text to CLI options

### DIFF
--- a/src/navi_bootstrap/cli.py
+++ b/src/navi_bootstrap/cli.py
@@ -49,8 +49,8 @@ def cli() -> None:
 
 
 @cli.command()
-@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path))
-@click.option("--pack", type=str, default=None)
+@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path), help="Path to the project spec YAML file")
+@click.option("--pack", type=str, default=None, help="Name of the template pack to validate")
 def validate(spec: Path, pack: str | None) -> None:
     """Validate a spec (and optionally a pack manifest)."""
     try:
@@ -72,10 +72,10 @@ def validate(spec: Path, pack: str | None) -> None:
 
 
 @cli.command("render")
-@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path))
-@click.option("--pack", required=True, type=str)
-@click.option("--out", type=click.Path(path_type=Path), default=None)
-@click.option("--dry-run", is_flag=True, default=False)
+@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path), help="Path to the project spec YAML file")
+@click.option("--pack", required=True, type=str, help="Name of the template pack to render")
+@click.option("--out", type=click.Path(path_type=Path), default=None, help="Output directory (defaults to spec name)")
+@click.option("--dry-run", is_flag=True, default=False, help="Preview output without writing files")
 @click.option("--skip-resolve", is_flag=True, default=False, help="Skip SHA resolution (offline)")
 @click.option("--trust", is_flag=True, default=False, help="Execute hooks from manifest (unsafe)")
 def render_cmd(
@@ -167,12 +167,12 @@ def render_cmd(
 
 
 @cli.command()
-@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path))
-@click.option("--pack", required=True, type=str)
+@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path), help="Path to the project spec YAML file")
+@click.option("--pack", required=True, type=str, help="Name of the template pack to apply")
 @click.option(
     "--target", required=True, type=click.Path(exists=True, file_okay=False, path_type=Path)
 )
-@click.option("--dry-run", is_flag=True, default=False)
+@click.option("--dry-run", is_flag=True, default=False, help="Preview output without writing files")
 @click.option("--skip-resolve", is_flag=True, default=False, help="Skip SHA resolution (offline)")
 @click.option(
     "--trust", is_flag=True, default=False, help="Execute hooks/validations from manifest (unsafe)"
@@ -271,8 +271,8 @@ def apply(
 
 
 @cli.command("diff")
-@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path))
-@click.option("--pack", required=True, type=str)
+@click.option("--spec", required=True, type=click.Path(exists=True, path_type=Path), help="Path to the project spec YAML file")
+@click.option("--pack", required=True, type=str, help="Name of the template pack to diff")
 @click.option(
     "--target", required=True, type=click.Path(exists=True, file_okay=False, path_type=Path)
 )


### PR DESCRIPTION
Add help text to CLI options missing descriptions in validate, render, apply, and diff commands.

Closes #30

## Description
<!-- Brief description of what this PR does -->

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Test coverage
- [ ] Refactor
- [ ] Security
- [ ] Breaking change

## Checklist
- [ ] My code follows the project's style (`ruff check src/navi_bootstrap/ tests/`)
- [ ] I have added tests for my changes
- [ ] I have updated documentation if needed
- [ ] All existing tests pass (`pytest tests/ -v`)

## Related Issues
<!-- Fixes #123, Related to #456 -->

## Additional Notes
