### PR TITLE
docs(claude): shorten pack-validator description

### DIFF
--- a/.claude/agents/pack-validator.md
+++ b/.claude/agents/pack-validator.md
@@ -1,6 +1,6 @@
 ---
 name: pack-validator
-description: Validates pack changes by running nboot validate, nboot diff, and pack-specific tests. Use after any modification to packs/<name>/ to catch render regressions before review.
+description: Validate pack changes: runs nboot validate/diff + pack tests. Use after any packs/<name>/ edit.
 tools: Read, Bash, Grep, Glob
 ---
 


### PR DESCRIPTION
## Summary

Single-line cleanup in response to the repo review pane's 6-findings-in-5-files report.

Trims the `pack-validator` subagent frontmatter `description:` from 186 to 108 chars. Mirrors the earlier `adversarial-reviewer.md` fix from PR #48.

## Context on the other 5 reported findings

- **cli.py apply/diff `--target` missing help=** — **already addressed** in commits `27d8646d` and `76778433` (pushed directly to main 2026-04-21, post-PR #41). Review threads just stale.
- **test_init.py `info` → `result` rename** — already applied in the rebased PR #42 code; thread stale.
- **test_hooks.py:39 / test_validate.py:54** — Grippy 🔵 LOW *positive* notes on the new hostile-manifest tests ("Someone finally listened to the fuzzer. Good."). Informational, not bugs.

## Test plan
- [ ] CI green (expect: trivial docs-only change)
- [ ] After merge: manually resolve the 5 stale review threads in GitHub UI