### PR TITLE
fix(ci): scope pip-audit to locked deps (was failing on transient runner pip CVE)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,14 @@ jobs:
         run: uv run bandit -r src/navi_bootstrap -ll
 
       - name: Audit dependencies (pip-audit)
-        run: uvx pip-audit==2.9.0
+        # Scope the audit to OUR locked dependency tree exported from uv,
+        # not the transient uvx environment. Otherwise pip-audit also scans
+        # its own runtime (which currently flags the runner's pip 26.0.1
+        # for GHSA-58qw-9mgm-455v / CVE-2026-3219, an unpatched pip CVE
+        # that has nothing to do with this project's dependencies).
+        run: |
+          uv export --format requirements.txt --no-emit-project --no-hashes             > /tmp/audit-deps.txt 2>/dev/null
+          uvx pip-audit==2.9.0 -r /tmp/audit-deps.txt
 
   # ── Required check: quality-gate ────────────────────────────────────
   # CONTRACT: org ruleset requires this exact check name


### PR DESCRIPTION
## Summary

The `security` job in `tests.yml` is failing on every PR right now because `uvx pip-audit==2.9.0` (with no `-r` argument) audits its own transient uvx environment, which contains the runner's `pip 26.0.1` — flagged by [GHSA-58qw-9mgm-455v](https://github.com/advisories/GHSA-58qw-9mgm-455v) / CVE-2026-3219 (pip tar/ZIP interpretation conflict, severity **medium**, **no patched version available**).

`pip` is **not in our `uv.lock`** — this audit was scanning the runner's Python environment, not our actual dependencies.

## Fix

Export the resolved lockfile to a requirements file via `uv export` and pass it to pip-audit with `-r`. Audits exactly our pinned tree, ignores the transient uvx pip.

Stderr from `uv export` is redirected to `/dev/null` because it writes `Resolved 36 packages in N ms` which would otherwise land at line 1 of the requirements file under shell redirection and trip pip-audit's parser.

## Test plan

- [x] Local repro: `uv export ... 2>/dev/null > /tmp/req.txt && uvx pip-audit==2.9.0 -r /tmp/req.txt` → "No known vulnerabilities found"
- [x] YAML loads under `yaml.safe_load`
- [ ] CI `security` step turns green on this PR
- [ ] Once merged, both #51 and #52 (currently blocked by this same failure) rebase and unblock

## Why this is the right fix (not just `--ignore-vuln`)

Adding `--ignore-vuln GHSA-58qw-9mgm-455v` would temporarily silence this specific advisory but leave the broader bug — auditing the runner's Python env instead of our project. When the next runner-image pip CVE drops we'd need another ignore. Scoping to our actual deps is the durable fix.